### PR TITLE
DM-33448: Integrate JupyterClient into the queue workers

### DIFF
--- a/src/noteburst/handlers/prototyping/handlers.py
+++ b/src/noteburst/handlers/prototyping/handlers.py
@@ -24,6 +24,7 @@ from .models import (
     PostNbexecRequest,
     PostRunPythonRequest,
     QueuedJob,
+    QueuedJobResult,
 )
 
 prototype_router = APIRouter(prefix="/prototype")
@@ -252,3 +253,19 @@ async def get_job(
 ) -> QueuedJob:
     job_metadata = await arq_queue.get_job_metadata(job_id)
     return await QueuedJob.from_job_metadata(job=job_metadata, request=request)
+
+
+@prototype_router.get(
+    "/jobs/{job_id}/result", description="Get the result from a completed job."
+)
+async def get_job_result(
+    *,
+    job_id: str,
+    request: Request,
+    logger: structlog.BoundLogger = Depends(logger_dependency),
+    arq_queue: ArqQueue = Depends(arq_dependency),
+) -> QueuedJobResult:
+    job_result = await arq_queue.get_job_result(job_id)
+    return await QueuedJobResult.from_job_result(
+        job=job_result, request=request
+    )

--- a/src/noteburst/handlers/prototyping/models.py
+++ b/src/noteburst/handlers/prototyping/models.py
@@ -87,3 +87,13 @@ class PostNbexecRequest(BaseModel):
             return self.ipynb
         else:
             return json.dumps(self.ipynb)
+
+
+class PostRunPythonRequest(BaseModel):
+    """The ``POST /runpython`` request body."""
+
+    py: str
+    """Python code to execute."""
+
+    kernel_name: str = "LSST"
+    """The name of the Jupyter kernel to execute this by."""

--- a/src/noteburst/handlers/prototyping/models.py
+++ b/src/noteburst/handlers/prototyping/models.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Union
 
 from arq.jobs import JobStatus
 from pydantic import AnyHttpUrl, BaseModel, Field
@@ -70,3 +71,19 @@ class QueuedJob(BaseModel):
             status=job.status,
             self_url=request.url_for("get_job", job_id=job.id),
         )
+
+
+class PostNbexecRequest(BaseModel):
+    """The ``POST /nbexec`` request body."""
+
+    ipynb: Union[str, Dict[str, Any]]
+    """The contents of a Jupyter notebook."""
+
+    kernel_name: str = "LSST"
+    """The name of the Jupyter kernel to execute this by."""
+
+    def get_ipynb_as_str(self) -> str:
+        if isinstance(self.ipynb, str):
+            return self.ipynb
+        else:
+            return json.dumps(self.ipynb)

--- a/src/noteburst/worker/functions/__init__.py
+++ b/src/noteburst/worker/functions/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["ping"]
+__all__ = ["ping", "nbexec"]
 
+from .nbexec import nbexec
 from .ping import ping

--- a/src/noteburst/worker/functions/__init__.py
+++ b/src/noteburst/worker/functions/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ["ping", "nbexec"]
+__all__ = ["ping", "nbexec", "run_python"]
 
 from .nbexec import nbexec
 from .ping import ping
+from .runpython import run_python

--- a/src/noteburst/worker/functions/nbexec.py
+++ b/src/noteburst/worker/functions/nbexec.py
@@ -1,0 +1,25 @@
+"""Execute a JupyterNotebook in a JupyterLab pod through the notebook
+execution extension.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+async def nbexec(
+    ctx: Dict[Any, Any], ipynb: str, *, kernel_name: str = "LSST"
+) -> str:
+    logger = ctx["logger"].bind(task="nbexec")
+    logger.info("Running nbexec")
+
+    jupyter_client = ctx["jupyter_client"]
+
+    parsed_notebook = json.loads(ipynb)
+    logger.debug("Got ipynb", ipynb=parsed_notebook)
+    executed_notebook = await jupyter_client.execute_notebook(
+        parsed_notebook, kernel_name=kernel_name
+    )
+
+    return json.dumps(executed_notebook)

--- a/src/noteburst/worker/functions/runpython.py
+++ b/src/noteburst/worker/functions/runpython.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+async def run_python(
+    ctx: Dict[Any, Any], py: str, *, kernel_name: str = "LSST"
+) -> str:
+    """Execute Python code in a JupyterLab pod with a specific Jupyter kernel.
+
+    Parameters
+    ----------
+    ctx
+        Arq worker context.
+    py : str
+        Python code to execute.
+    kernel_name : str
+        Name of the Python kernel.
+
+    Returns
+    -------
+    result : str
+        The standard-out
+    """
+    logger = ctx["logger"].bind(task="run_python")
+    logger.info("Running run_python", py=py)
+
+    jupyter_client = ctx["jupyter_client"]
+    async with jupyter_client.open_lab_session(
+        kernel_name=kernel_name
+    ) as session:
+        result = await session.run_python(py)
+    logger.info("Running run_python", result=result)
+
+    return result

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -51,7 +51,7 @@ async def startup(ctx: Dict[Any, Any]) -> None:
     http_client = httpx.AsyncClient()
     ctx["http_client"] = http_client
 
-    user = User(username=identity.username, uid=identity.uuid)
+    user = User(username=identity.username, uid=identity.uid)
     authed_user = await user.login(
         scopes=["exec:notebook"], http_client=http_client
     )

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -16,7 +16,7 @@ from noteburst.jupyterclient.jupyterlab import (
 )
 from noteburst.jupyterclient.user import User
 
-from .functions import ping
+from .functions import nbexec, ping
 from .identity import IdentityManager
 
 config = WorkerConfig()
@@ -110,7 +110,7 @@ class WorkerSettings:
     See `arq.worker.Worker` for details on these attributes.
     """
 
-    functions = [ping]
+    functions = [ping, nbexec]
 
     redis_settings = config.arq_redis_settings
 

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -16,7 +16,7 @@ from noteburst.jupyterclient.jupyterlab import (
 )
 from noteburst.jupyterclient.user import User
 
-from .functions import nbexec, ping
+from .functions import nbexec, ping, run_python
 from .identity import IdentityManager
 
 config = WorkerConfig()
@@ -110,7 +110,7 @@ class WorkerSettings:
     See `arq.worker.Worker` for details on these attributes.
     """
 
-    functions = [ping, nbexec]
+    functions = [ping, nbexec, run_python]
 
     redis_settings = config.arq_redis_settings
 

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import httpx
 import structlog
 from safir.logging import configure_logging
 
 from noteburst.config import WorkerConfig
+from noteburst.jupyterclient.jupyterlab import (
+    JupyterClient,
+    JupyterConfig,
+    JupyterImageSelector,
+)
+from noteburst.jupyterclient.user import User
 
 from .functions import ping
 from .identity import IdentityManager
@@ -40,6 +47,30 @@ async def startup(ctx: Dict[Any, Any]) -> None:
     identity = await identity_manager.get_identity()
 
     logger = logger.bind(worker_username=identity.username)
+
+    http_client = httpx.AsyncClient()
+    ctx["http_client"] = http_client
+
+    user = User(username=identity.username, uid=identity.uuid)
+    authed_user = await user.login(
+        scopes=["exec:notebook"], http_client=http_client
+    )
+    logger.info("Authenticated the worker's user.")
+
+    jupyter_config = JupyterConfig(
+        image_selector=JupyterImageSelector.RECOMMENDED
+    )
+    jupyter_client = JupyterClient(
+        user=authed_user, logger=logger, config=jupyter_config
+    )
+    await jupyter_client.log_into_hub()
+    image_info = await jupyter_client.spawn_lab()
+    logger = logger.bind(image_ref=image_info.reference)
+    async for progress in jupyter_client.spawn_progress():
+        continue
+    await jupyter_client.log_into_lab()
+    ctx["jupyter_client"] = jupyter_client
+
     ctx["logger"] = logger
 
     logger.info("Start up complete")
@@ -49,11 +80,26 @@ async def shutdown(ctx: Dict[Any, Any]) -> None:
     """Runs during worker shut-down to release the JupyterLab resources
     and identitiy claim.
     """
-    logger = structlog.get_logger(__name__)
+    if "logger" in ctx.keys():
+        logger = ctx["logger"]
+    else:
+        logger = structlog.get_logger(__name__)
     logger.info("Running worker shutdown.")
 
-    if "identity_manager" in ctx.keys():
+    try:
         await ctx["identity_manager"].close()
+    except Exception as e:
+        logger.warning("Issue closing the identity manager: %s", str(e))
+
+    try:
+        await ctx["http_client"].aclose()
+    except Exception as e:
+        logger.warning("Issue closing the http_client: %s", str(e))
+
+    try:
+        await ctx["jupyter_client"].close()
+    except Exception as e:
+        logger.warning("Issue closing the Jupyter client: %s", str(e))
 
     logger.info("Worker shutdown complete.")
 

--- a/tests/handlers/prototyping_test.py
+++ b/tests/handlers/prototyping_test.py
@@ -37,3 +37,16 @@ async def test_post_ping(client: AsyncClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "in_progress"
+
+    # Toggle the job to complete
+    await arq_queue.set_complete(job_id, result="pong")
+    response = await client.get(job_url)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "complete"
+    result_url = data["result_url"]
+
+    response = await client.get(result_url)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "pong"


### PR DESCRIPTION
- On worker start-up, open a JupyterHub/JupyterLab client that connects to JupyterHub and starts a JupyterLab pod with the claim Science Platform identity.
- The nbexec worker function uses the RSP extension API `/user/:username/rubin/execution` that converts a notebook via nbconvert.
- The runpython worker function is an alternative approach that executes Python code on JupyterLab, but didn't pan out for this application because the results are not equivalent to running a notebook (results aren't automatically echoed).
- Add endpoint for getting the result of a completed job.