### PR TITLE
DM-35205: Make uid configuration optional for worker identities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Change log
 Unreleased
 ==========
 
+- The worker identity configuration can now omit the ``uid`` field for environments where Gafaelfawr is able to assign a UID (e.g. through an LDAP backend).
+- A new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
 - Noteburst now uses the arq client and dependency from Safir 3.2, which was originally developed from Noteburst.
 
 0.3.0 (2022-05-24)

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -102,6 +102,12 @@ class WorkerConfig(Config):
         ),
     )
 
+    worker_token_lifetime: int = Field(
+        2419200,
+        env="NOTEBURST_WORKER_TOKEN_LIFETIME",
+        description="Worker auth token lifetime in seconds.",
+    )
+
     @property
     def aioredlock_redis_config(self) -> List[str]:
         """Redis configurations for aioredlock."""

--- a/src/noteburst/jupyterclient/user.py
+++ b/src/noteburst/jupyterclient/user.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from noteburst.config import config
 
@@ -25,8 +25,11 @@ class User:
     username: str
     """The user's username."""
 
-    uid: str
-    """The user's UID."""
+    uid: Optional[str]
+    """The user's UID.
+
+    This can be set as `None` if the authentication services provides the UID.
+    """
 
     async def login(
         self, *, scopes: List[str], http_client: httpx.AsyncClient
@@ -52,8 +55,9 @@ class AuthenticatedUser(User):
     @classmethod
     async def create(
         cls,
+        *,
         username: str,
-        uid: str,
+        uid: Optional[str],
         scopes: List[str],
         http_client: httpx.AsyncClient,
     ) -> AuthenticatedUser:
@@ -61,14 +65,27 @@ class AuthenticatedUser(User):
 
         Parameters
         ----------
-        user: `User`
-            The user to log in.
+        username : `str`
+            The username.
+        uid : `str` or `None`
+            The user's UID. This can be `None` if the authentication service
+            assigns the UID.
         scopes : `list` of `str`
             The scopes the user's token should possess.
         http_client : httpx.Client
             The httpx client session.
         """
         token_url = f"{config.environment_url}/auth/api/v1/tokens"
+        token_request_data = {
+            "username": username,
+            "name": "Noteburst",
+            "token_type": "user",
+            "token_name": f"noteburst {str(float(time.time()))}",
+            "scopes": scopes,
+            "expires": int(time.time() + 2419200),
+        }
+        if uid:
+            token_request_data["uid"] = uid
         r = await http_client.post(
             token_url,
             headers={
@@ -76,15 +93,7 @@ class AuthenticatedUser(User):
                     f"Bearer {config.gafaelfawr_token.get_secret_value()}"
                 )
             },
-            json={
-                "username": username,
-                "name": "Noteburst",
-                "token_type": "user",
-                "token_name": f"noteburst {str(float(time.time()))}",
-                "scopes": scopes,
-                "expires": int(time.time() + 2419200),
-                "uid": uid,
-            },
+            json=token_request_data,
         )
         r.raise_for_status()
         body = r.json()

--- a/src/noteburst/jupyterclient/user.py
+++ b/src/noteburst/jupyterclient/user.py
@@ -32,13 +32,18 @@ class User:
     """
 
     async def login(
-        self, *, scopes: List[str], http_client: httpx.AsyncClient
+        self,
+        *,
+        scopes: List[str],
+        http_client: httpx.AsyncClient,
+        token_lifetime: int,
     ) -> AuthenticatedUser:
         return await AuthenticatedUser.create(
             username=self.username,
             uid=self.uid,
             scopes=scopes,
             http_client=http_client,
+            lifetime=token_lifetime,
         )
 
 
@@ -60,6 +65,7 @@ class AuthenticatedUser(User):
         uid: Optional[str],
         scopes: List[str],
         http_client: httpx.AsyncClient,
+        lifetime: int,
     ) -> AuthenticatedUser:
         """Create an authenticated user by logging into the Science Platform.
 
@@ -74,6 +80,8 @@ class AuthenticatedUser(User):
             The scopes the user's token should possess.
         http_client : httpx.Client
             The httpx client session.
+        lifetime : int
+            The lifetime of the authentication token, in seconds.
         """
         token_url = f"{config.environment_url}/auth/api/v1/tokens"
         token_request_data = {
@@ -82,7 +90,7 @@ class AuthenticatedUser(User):
             "token_type": "user",
             "token_name": f"noteburst {str(float(time.time()))}",
             "scopes": scopes,
-            "expires": int(time.time() + 2419200),
+            "expires": int(time.time() + lifetime),
         }
         if uid:
             token_request_data["uid"] = uid

--- a/src/noteburst/worker/identity.py
+++ b/src/noteburst/worker/identity.py
@@ -26,8 +26,11 @@ class IdentityModel(BaseModel):
     username: str
     """The username of the user account."""
 
-    uid: str
-    """The UID of the user account."""
+    uid: Optional[str] = None
+    """The UID of the user account.
+
+    This can be `None` if the authentication system assigns the UID.
+    """
 
 
 class IdentityConfigModel(BaseModel):
@@ -47,7 +50,7 @@ class IdentityClaim:
     username: str
     """The username of the user account."""
 
-    uid: str
+    uid: Optional[str]
     """The UID of the user account."""
 
     lock: Lock
@@ -158,7 +161,7 @@ class IdentityManager:
             try:
                 # We don't set the timeout argument on lock; in doing so we
                 # use aioredlock's built-in watchdog that renews locks.
-                lock = await self.lock_manager.lock(identity.uid)
+                lock = await self.lock_manager.lock(identity.username)
             except LockError:
                 self._logger.debug(
                     "Identity already claimed", username=identity.username

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -60,7 +60,9 @@ async def startup(ctx: Dict[Any, Any]) -> None:
 
         user = User(username=identity.username, uid=identity.uid)
         authed_user = await user.login(
-            scopes=["exec:notebook"], http_client=http_client
+            scopes=["exec:notebook"],
+            http_client=http_client,
+            token_lifetime=config.worker_token_lifetime,
         )
         logger.info("Authenticated the worker's user.")
 

--- a/tests/jupyterclient/jupyterclient_test.py
+++ b/tests/jupyterclient/jupyterclient_test.py
@@ -41,7 +41,9 @@ async def test_jupyterclient(
 
     async with httpx.AsyncClient() as http_client:
         authed_user = await user.login(
-            scopes=["exec:notebook"], http_client=http_client
+            scopes=["exec:notebook"],
+            http_client=http_client,
+            token_lifetime=3600,
         )
         async with JupyterClient(
             user=authed_user, logger=logger, config=jupyter_config

--- a/tests/jupyterclient/user_test.py
+++ b/tests/jupyterclient/user_test.py
@@ -21,7 +21,9 @@ async def test_generate_token(respx_mock: respx.Router) -> None:
     scopes = ["exec:notebook"]
 
     async with httpx.AsyncClient() as http_client:
-        user = await u.login(scopes=scopes, http_client=http_client)
+        user = await u.login(
+            scopes=scopes, http_client=http_client, token_lifetime=3600
+        )
     assert user.username == "someuser"
     assert user.uid == "1234"
     assert user.scopes == ["exec:notebook"]


### PR DESCRIPTION
- The worker identity configuration can now omit the `uid` field for environments where Gafaelfawr is able to assign a UID (e.g. through an LDAP backend).
- A new `NOTEBURST_WORKER_TOKEN_LIFETIME` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behaviour, 28 days.