### PR TITLE
DM-35203: Make the worker's image selection configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ Unreleased
 ==========
 
 - The worker identity configuration can now omit the ``uid`` field for environments where Gafaelfawr is able to assign a UID (e.g. through an LDAP backend).
-- A new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
+- New configurations for workers:
+    - The new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
+    - ``NOTEBURST_WORKER_IMAGE_SELECTOR`` allows you to specify what stream of Nublado image to select. Can be ``recommended``, ``weekly`` or ``reference``. If the latter, you can specify the specific Docker Image with ``NOTEBURST_WORKER_IMAGE_REFERENCE``.
 - Noteburst now uses the arq client and dependency from Safir 3.2, which was originally developed from Noteburst.
 
 0.3.0 (2022-05-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 - The worker identity configuration can now omit the ``uid`` field for environments where Gafaelfawr is able to assign a UID (e.g. through an LDAP backend).
 - New configurations for workers:
     - The new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
+    - ``NOTEBURST_WORKER_TOKEN_SCOPES`` environment variable enables you to set what token scopes the nublado2 bot users should have, as a comma-separated list.
     - ``NOTEBURST_WORKER_IMAGE_SELECTOR`` allows you to specify what stream of Nublado image to select. Can be ``recommended``, ``weekly`` or ``reference``. If the latter, you can specify the specific Docker Image with ``NOTEBURST_WORKER_IMAGE_REFERENCE``.
 - Noteburst now uses the arq client and dependency from Safir 3.2, which was originally developed from Noteburst.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,14 +2,15 @@
 Change log
 ##########
 
-Unreleased
-==========
+0.4.0 (2022-06-15)
+==================
 
 - The worker identity configuration can now omit the ``uid`` field for environments where Gafaelfawr is able to assign a UID (e.g. through an LDAP backend).
 - New configurations for workers:
     - The new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
     - ``NOTEBURST_WORKER_TOKEN_SCOPES`` environment variable enables you to set what token scopes the nublado2 bot users should have, as a comma-separated list.
     - ``NOTEBURST_WORKER_IMAGE_SELECTOR`` allows you to specify what stream of Nublado image to select. Can be ``recommended``, ``weekly`` or ``reference``. If the latter, you can specify the specific Docker Image with ``NOTEBURST_WORKER_IMAGE_REFERENCE``.
+    - The ``NOTEBURST_WORKER_KEEPALIVE`` configuration controls whether the worker keep alive function is run (to default the Nublado pod culler), and at what frequencey. Set to ``disabled`` to disable; ``fast`` to run every 30 seconds; or ``normal`` to run every 5 minutes.
 - Noteburst now uses the arq client and dependency from Safir 3.2, which was originally developed from Noteburst.
 
 0.3.0 (2022-05-24)

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -54,6 +54,19 @@ class JupyterImageSelector(str, Enum):
     """Select a specific image by reference."""
 
 
+class WorkerKeepAliveSetting(str, Enum):
+    """Modes for the worker keep-alive function."""
+
+    disabled = "disabled"
+    """Do not run a keep-alive function."""
+
+    fast = "fast"
+    """Run the keep-alive function at a high frequency (every 30 seconds)."""
+
+    normal = "normal"
+    """Run the keep-alive function at a slower frequencey (i.e. 5 minutes)."""
+
+
 class Config(BaseSettings):
 
     name: str = Field("Noteburst", env="SAFIR_NAME")
@@ -149,6 +162,10 @@ class WorkerConfig(Config):
             "Docker image reference, if NOTEBURST_WORKER_IMAGE_SELECTOR is "
             "``reference``."
         ),
+    )
+
+    worker_keepalive: WorkerKeepAliveSetting = Field(
+        WorkerKeepAliveSetting.normal, env="NOTEBURST_WORKER_KEEPALIVE"
     )
 
     @property

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -128,6 +128,14 @@ class WorkerConfig(Config):
         description="Worker auth token lifetime in seconds.",
     )
 
+    worker_token_scopes: str = Field(
+        "exec:notebook",
+        env="NOTEBURST_WORKER_TOKEN_SCOPES",
+        description=(
+            "Worker (nublado2 pod) token scopes as a comma-separated string."
+        ),
+    )
+
     image_selector: JupyterImageSelector = Field(
         JupyterImageSelector.recommended,
         env="NOTEBURST_WORKER_IMAGE_SELECTOR",
@@ -165,6 +173,13 @@ class WorkerConfig(Config):
             )
 
         return v
+
+    @property
+    def parsed_worker_token_scopes(self) -> List[str]:
+        """Sequence of worker token scopes, parsed from the comma-separated
+        list in `worker_token_scopes`.
+        """
+        return [t.strip() for t in self.worker_token_scopes.split(",") if t]
 
 
 config = Config()

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -14,7 +14,6 @@ from noteburst.jupyterclient.jupyterlab import (
     JupyterClient,
     JupyterConfig,
     JupyterError,
-    JupyterImageSelector,
 )
 from noteburst.jupyterclient.user import User
 
@@ -50,7 +49,8 @@ async def startup(ctx: Dict[Any, Any]) -> None:
     ctx["http_client"] = http_client
 
     jupyter_config = JupyterConfig(
-        image_selector=JupyterImageSelector.RECOMMENDED
+        image_selector=config.image_selector,
+        image_reference=config.image_reference,
     )
 
     identity = await identity_manager.get_identity()

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -60,7 +60,7 @@ async def startup(ctx: Dict[Any, Any]) -> None:
 
         user = User(username=identity.username, uid=identity.uid)
         authed_user = await user.login(
-            scopes=["exec:notebook"],
+            scopes=config.parsed_worker_token_scopes,
             http_client=http_client,
             token_lifetime=config.worker_token_lifetime,
         )

--- a/tests/jupyterclient/jupyterclient_test.py
+++ b/tests/jupyterclient/jupyterclient_test.py
@@ -9,11 +9,8 @@ import pytest
 import respx
 import structlog
 
-from noteburst.jupyterclient.jupyterlab import (
-    JupyterClient,
-    JupyterConfig,
-    JupyterImageSelector,
-)
+from noteburst.config import JupyterImageSelector
+from noteburst.jupyterclient.jupyterlab import JupyterClient, JupyterConfig
 from noteburst.jupyterclient.user import User
 from tests.support.gafaelfawr import mock_gafaelfawr
 
@@ -36,7 +33,7 @@ async def test_jupyterclient(
     logger = structlog.get_logger(__name__)
 
     jupyter_config = JupyterConfig(
-        image_selector=JupyterImageSelector.RECOMMENDED
+        image_selector=JupyterImageSelector.recommended
     )
 
     async with httpx.AsyncClient() as http_client:


### PR DESCRIPTION
Several new configurations for Noteburst workers:

- The new ``NOTEBURST_WORKER_TOKEN_LIFETIME`` environment variable enables you to configure the lifetime of the workers' authentication tokens. The default matches the existing behavior, 28 days.
- ``NOTEBURST_WORKER_TOKEN_SCOPES`` environment variable enables you to set what token scopes the nublado2 bot users should have, as a comma-separated list.
- ``NOTEBURST_WORKER_IMAGE_SELECTOR`` allows you to specify what stream of Nublado image to select. Can be ``recommended``, ``weekly`` or ``reference``. If the latter, you can specify the specific Docker Image with ``NOTEBURST_WORKER_IMAGE_REFERENCE``.
- The ``NOTEBURST_WORKER_KEEPALIVE`` configuration controls whether the worker keep alive function is run (to default the Nublado pod culler), and at what frequencey. Set to ``disabled`` to disable; ``fast`` to run every 30 seconds; or ``normal`` to run every 5 minutes.
- Noteburst now uses the arq client and dependency from Safir 3.2, which was originally developed from Noteburst.
