### PR TITLE
DM-39336: Add configurations for the Nublado API paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.7.0 (2023-05-22)
+
+- The JupyterHub service's URL path prefix is now configurable with the `NOTEBURST_JUPYTERHUB_PATH_PREFIX` environment variable. The default is `/nb/`, which is the existing value.
+
 ## 0.6.3 (2023-04-20)
 
 - Fix how failed notebook executions are handled. Previously failed notebooks would prevent Noteburst from getting the results of the execution job. Now the job is shown as concluded but unsuccessful by the `/v1/notebooks/{job_id}` endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.0 (2023-05-22)
 
 - The JupyterHub service's URL path prefix is now configurable with the `NOTEBURST_JUPYTERHUB_PATH_PREFIX` environment variable. The default is `/nb/`, which is the existing value.
+- The Nublado JupyterLab Controller service's URL path prefix is configurable with the `NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX` environment variable. The default is `/nublado`, which is the existing value.
 
 ## 0.6.3 (2023-04-20)
 

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -92,6 +92,12 @@ class Config(BaseSettings):
         description="The path prefix for the JupyterHub service.",
     )
 
+    nublado_controller_path_prefix: str = Field(
+        "/nublado",
+        env="NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX",
+        description="The path prefix for the Nublado controller service.",
+    )
+
     gafaelfawr_token: SecretStr = Field(env="NOTEBURST_GAFAELFAWR_TOKEN")
     """This token is used to make an admin API call to Gafaelfawr to get a
     token for the user.

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -86,6 +86,12 @@ class Config(BaseSettings):
     This is used for creating URLs to services, such as JupyterHub.
     """
 
+    jupyterhub_path_prefix: str = Field(
+        "/nb/",
+        env="NOTEBURST_JUPYTERHUB_PATH_PREFIX",
+        description="The path prefix for the JupyterHub service.",
+    )
+
     gafaelfawr_token: SecretStr = Field(env="NOTEBURST_GAFAELFAWR_TOKEN")
     """This token is used to make an admin API call to Gafaelfawr to get a
     token for the user.

--- a/src/noteburst/jupyterclient/jupyterlab.py
+++ b/src/noteburst/jupyterclient/jupyterlab.py
@@ -432,8 +432,9 @@ class JupyterClient:
         # sharing the session, but that shouldn't matter.
         assert noteburst_config.gafaelfawr_token
         self._lab_controller_client = LabControllerClient(
-            self.http_client,
-            noteburst_config.gafaelfawr_token.get_secret_value(),
+            http_client=self.http_client,
+            token=noteburst_config.gafaelfawr_token.get_secret_value(),
+            url_prefix=noteburst_config.nublado_controller_path_prefix,
         )
 
     async def __aexit__(self, *exc_info: Any) -> None:

--- a/src/noteburst/jupyterclient/labcontroller.py
+++ b/src/noteburst/jupyterclient/labcontroller.py
@@ -124,11 +124,16 @@ class LabControllerClient:
         The HTTPX async client.
     token
         The Gafaelfawr token.
+    url_prefix
+        The URL path prefix for Nublado JupyterLab Controller service.
     """
 
-    def __init__(self, http_client: httpx.AsyncClient, token: str) -> None:
+    def __init__(
+        self, *, http_client: httpx.AsyncClient, token: str, url_prefix: str
+    ) -> None:
         self._http_client = http_client
         self._token = token
+        self._url_prefix = url_prefix
 
     async def get_latest_weekly(self) -> JupyterImage:
         """Image for the latest weekly version.
@@ -192,7 +197,9 @@ class LabControllerClient:
 
     async def _get_images(self) -> LabControllerImages:
         headers = {"Authorization": f"bearer {self._token}"}
-        url = urljoin(config.environment_url, "/nublado/spawner/v1/images")
+        url = urljoin(
+            config.environment_url, f"{self._url_prefix}/spawner/v1/images"
+        )
 
         r = await self._http_client.get(url, headers=headers)
         if r.status_code != 200:

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -49,6 +49,7 @@ async def startup(ctx: dict[Any, Any]) -> None:
     ctx["http_client"] = http_client
 
     jupyter_config = JupyterConfig(
+        url_prefix=config.jupyterhub_path_prefix,
         image_selector=config.image_selector,
         image_reference=config.image_reference,
     )


### PR DESCRIPTION
- The JupyterHub service's URL path prefix is now configurable with the `NOTEBURST_JUPYTERHUB_PATH_PREFIX` environment variable. The default is `/nb`, which is the existing value.
- The Nublado JupyterLab Controller service's URL path prefix is configurable with the `NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX` environment variable. The default is `/nublado`, which is the existing value.