### PR TITLE
Add gid to worker, make uid/gid int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.11.0'></a>
+## 0.11.0 (2024-04-24)
+
+### Bug fixes
+
+- Nublado v3 requires gid as well as uid, and both uid and gid should be int rather than str
+
 <a id='changelog-0.10.0'></a>
 
 ## 0.10.0 (2024-03-26)

--- a/src/noteburst/jupyterclient/user.py
+++ b/src/noteburst/jupyterclient/user.py
@@ -24,10 +24,16 @@ class User:
     username: str
     """The user's username."""
 
-    uid: str | None
+    uid: int | None
     """The user's UID.
 
     This can be set as `None` if the authentication services provides the UID.
+    """
+
+    gid: int | None
+    """The user's GID.
+
+    This can be set as `None` if the authentication services provides the GID.
     """
 
     async def login(
@@ -40,6 +46,7 @@ class User:
         return await AuthenticatedUser.create(
             username=self.username,
             uid=self.uid,
+            gid=self.gid,
             scopes=scopes,
             http_client=http_client,
             lifetime=token_lifetime,
@@ -61,7 +68,8 @@ class AuthenticatedUser(User):
         cls,
         *,
         username: str,
-        uid: str | None,
+        uid: int | None,
+        gid: int | None,
         scopes: list[str],
         http_client: httpx.AsyncClient,
         lifetime: int,
@@ -75,6 +83,9 @@ class AuthenticatedUser(User):
         uid
             The user's UID. This can be `None` if the authentication service
             assigns the UID.
+        gid
+            The user's GID. This can be `None` if the authentication service
+            assigns the GID.
         scopes
             The scopes the user's token should possess.
         http_client
@@ -93,6 +104,8 @@ class AuthenticatedUser(User):
         }
         if uid:
             token_request_data["uid"] = uid
+        if gid:
+            token_request_data["gid"] = gid
         r = await http_client.post(
             token_url,
             headers={
@@ -107,6 +120,7 @@ class AuthenticatedUser(User):
         return cls(
             username=username,
             uid=uid,
+            gid=gid,
             token=body["token"],
             scopes=scopes,
         )

--- a/src/noteburst/worker/identity.py
+++ b/src/noteburst/worker/identity.py
@@ -28,11 +28,21 @@ class IdentityModel(BaseModel):
     ]
 
     uid: Annotated[
-        str | None,
+        int | None,
         Field(
             description=(
                 "The UID of the user account. This can be `None` if the "
                 "authentication system assigns the UID."
+            )
+        ),
+    ] = None
+
+    gid: Annotated[
+        int | None,
+        Field(
+            description=(
+                "The GID of the user account. This can be `None` if the "
+                "authentication system assigns the GID."
             )
         ),
     ] = None
@@ -56,8 +66,11 @@ class IdentityClaim:
     username: str
     """The username of the user account."""
 
-    uid: str | None
+    uid: int | None
     """The UID of the user account."""
+
+    gid: int | None
+    """The GID of the user account."""
 
     lock: Lock
     """The aioredlock lock that this claim holds."""
@@ -170,7 +183,10 @@ class IdentityManager:
 
             self._logger.info("Claimed identity", username=identity.username)
             self._current_identity = IdentityClaim(
-                username=identity.username, uid=identity.uid, lock=lock
+                username=identity.username,
+                uid=identity.uid,
+                gid=identity.gid,
+                lock=lock,
             )
             return self._current_identity
 

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -70,7 +70,9 @@ async def startup(ctx: dict[Any, Any]) -> None:
     while True:
         logger = logger.bind(worker_username=identity.username)
 
-        user = User(username=identity.username, uid=identity.uid)
+        user = User(
+            username=identity.username, uid=identity.uid, gid=identity.gid
+        )
         authed_user = await user.login(
             scopes=config.parsed_worker_token_scopes,
             http_client=http_client,

--- a/tests/jupyterclient/user_test.py
+++ b/tests/jupyterclient/user_test.py
@@ -12,8 +12,8 @@ from tests.support.gafaelfawr import mock_gafaelfawr
 
 @pytest.mark.asyncio
 async def test_generate_token(respx_mock: respx.Router) -> None:
-    u = User(username="someuser", uid="1234")
-    mock_gafaelfawr(respx_mock, u.username, u.uid)
+    u = User(username="someuser", uid=1234, gid=5678)
+    mock_gafaelfawr(respx_mock, u.username, u.uid, u.gid)
     scopes = ["exec:notebook"]
 
     async with httpx.AsyncClient() as http_client:
@@ -21,6 +21,7 @@ async def test_generate_token(respx_mock: respx.Router) -> None:
             scopes=scopes, http_client=http_client, token_lifetime=3600
         )
     assert user.username == "someuser"
-    assert user.uid == "1234"
+    assert user.uid == 1234
+    assert user.gid == 5678
     assert user.scopes == ["exec:notebook"]
     assert user.token.startswith("gt-")

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -36,7 +36,8 @@ def make_gafaelfawr_token(username: str | None = None) -> str:
 def mock_gafaelfawr(
     respx_mock: respx.Router,
     username: str | None = None,
-    uid: str | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
 ) -> None:
     """Mock out the call to Gafaelfawr ``/auth/api/v1/tokens`` endpoint to
     create a user token.
@@ -60,11 +61,14 @@ def mock_gafaelfawr(
             "expires": ANY,
             "name": "Noteburst",
             "uid": ANY,
+            "gid": ANY,
         }
         if username:
             assert request_json["username"] == username
         if uid:
             assert request_json["uid"] == uid
+        if gid:
+            assert request_json["gid"] == gid
         assert request_json["token_name"].startswith("noteburst ")
         assert request_json["expires"] > time.time()
         response = {"token": make_gafaelfawr_token(request_json["username"])}


### PR DESCRIPTION
If the auth system doesn't provide uid/gid for users (roughly speaking, if the auth system isn't LDAP-backed) the noteburst system needs to provide both: the Nublado controller needs both a uid and a gid in order to spawn a user.

At some time, uid became a string; according to the (unused, presumably) values-minikube.yaml for Noteburst it used to be an int.  Since uid and gid are Unix account concepts, they're both properly ints rather than strings.

This PR implements that change in the code and test harness.

A different approach would be to drop those fields entirely, and just insist that the auth system do the work for us.  This will work at IDF and USDF, anyway, which is probably all we really care about.