### PR TITLE
DM-44136: Switch to creating Gafaelfawr service tokens

### DIFF
--- a/changelog.d/20240501_080604_rra_DM_44136.md
+++ b/changelog.d/20240501_080604_rra_DM_44136.md
@@ -1,0 +1,3 @@
+### New features
+
+- Create Gafaelfawr service tokens instead of user tokens for authenticated calls to JupyterHub and JupyterLab. Gafaelfawr is standardizing on the new service token type for all service-to-service authentication.

--- a/src/noteburst/jupyterclient/user.py
+++ b/src/noteburst/jupyterclient/user.py
@@ -97,7 +97,7 @@ class AuthenticatedUser(User):
         token_request_data = {
             "username": username,
             "name": "Noteburst",
-            "token_type": "user",
+            "token_type": "service",
             "token_name": f"noteburst {float(time.time())!s}",
             "scopes": scopes,
             "expires": int(time.time() + lifetime),

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -55,7 +55,7 @@ def mock_gafaelfawr(
         # so we can't check it here.
         assert request_json == {
             "username": ANY,
-            "token_type": "user",
+            "token_type": "service",
             "token_name": ANY,
             "scopes": ["exec:notebook"],
             "expires": ANY,


### PR DESCRIPTION
Create Gafaelfawr service tokens instead of user tokens for authenticated calls to JupyterHub and JupyterLab. Gafaelfawr is standardizing on the new service token type for all service-to-service authentication.