### PR TITLE
DM-49407: Restart worker on any keepalive exception

### DIFF
--- a/changelog.d/20250310_142400_danfuchs_HEAD.md
+++ b/changelog.d/20250310_142400_danfuchs_HEAD.md
@@ -1,0 +1,9 @@
+### New features
+
+- New worker config options:
+  - `worker_keepalive_retries`: How many times to retry the keepalive check.
+  - `worker_keepalive_idle`: How long to wait in between each keepalive attempt.
+
+### Bug fixes
+
+- Restart the worker on any exception in the keepalive cron. Some of the exception types changed with the shared Nublado client.

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings
 from safir.arq import ArqMode
 from safir.logging import LogLevel, Profile
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
+from safir.pydantic import HumanTimedelta
 
 __all__ = [
     "Config",
@@ -278,6 +279,31 @@ class WorkerConfig(Config):
             ),
         ),
     ] = WorkerKeepAliveSetting.normal
+
+    worker_keepalive_retries: Annotated[
+        int,
+        Field(
+            default=3,
+            alias="NOTEBURST_WORKER_KEEPALIVE_RETRIES",
+            description=(
+                "How many times to retry the worker keepalive check before "
+                "restarting the worker."
+            ),
+            gt=0,
+        ),
+    ]
+
+    worker_keepalive_idle: Annotated[
+        HumanTimedelta,
+        Field(
+            default="5s",
+            alias="NOTEBURST_WORKER_KEEPALIVE_IDLE",
+            description=(
+                "How long to wait in between each attempt of the worker "
+                "healthcheck."
+            ),
+        ),
+    ]
 
     @property
     def aioredlock_redis_config(self) -> list[str]:

--- a/src/noteburst/worker/functions/__init__.py
+++ b/src/noteburst/worker/functions/__init__.py
@@ -1,6 +1,6 @@
-__all__ = ["keep_alive", "nbexec", "ping", "run_python"]
+__all__ = ["make_keep_alive", "nbexec", "ping", "run_python"]
 
-from .keepalive import keep_alive
+from .keepalive import make_keep_alive
 from .nbexec import nbexec
 from .ping import ping
 from .runpython import run_python

--- a/src/noteburst/worker/functions/keepalive.py
+++ b/src/noteburst/worker/functions/keepalive.py
@@ -2,19 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
+from datetime import timedelta
 from typing import Any
 
-from rubin.nublado.client.exceptions import JupyterWebSocketError
+from arq.typing import WorkerCoroutine
+from rubin.nublado.client.exceptions import (
+    JupyterWebError,
+    JupyterWebSocketError,
+)
 
 
-async def keep_alive(ctx: dict[Any, Any]) -> str:
+async def _keep_alive(
+    ctx: dict[Any, Any], retries: int, idle: timedelta
+) -> str:
     """Execute Python code in a JupyterLab pod with a specific Jupyter kernel.
+
+    Exit the worker process if this is unsuccessfull after some attempts.
 
     Parameters
     ----------
     ctx
         Arq worker context.
+    retries
+        The number of times to retry running the code.
+    idle
+        The amount of time to wait in between retries.
 
     Returns
     -------
@@ -25,18 +39,52 @@ async def keep_alive(ctx: dict[Any, Any]) -> str:
     logger.info("Running keep_alive")
 
     jupyter_client = ctx["jupyter_client"]
-    try:
-        async with jupyter_client.open_lab_session(
-            kernel_name="LSST"
-        ) as session:
-            await session.run_python("print('alive')")
-    except JupyterWebSocketError as e:
-        logger.exception("keep_alive error", jupyter_status=e.status)
-        if e.status and e.status >= 400 and e.status < 500:
+    exit_msg = ""
+    for attempt in range(retries):
+        try:
+            async with jupyter_client.open_lab_session(
+                kernel_name="LSST"
+            ) as session:
+                await session.run_python("print('alive')")
+            break
+        except (JupyterWebSocketError, JupyterWebError) as e:
             logger.exception(
-                "Authentication error to Jupyter. Forcing worker shutdown",
+                "Error from Jupyter. Forcing worker shutdown",
                 jupyter_status=e.status,
+                attempt=attempt,
+                retries=retries,
             )
-            sys.exit("400 class error from Jupyter")
+            exit_msg = f"{e.status or 'Unknown'} error from Jupyter"
+        except Exception:
+            logger.exception(
+                "keep_alive error", attempt=attempt, retries=retries
+            )
+            exit_msg = "keep_alive error"
+
+        if attempt + 1 == retries:
+            sys.exit(exit_msg)
+        await asyncio.sleep(idle.total_seconds())
 
     return "alive"
+
+
+def make_keep_alive(retries: int, idle: timedelta) -> WorkerCoroutine:
+    """Make a keep-alive coroutine with retry and idle settings.
+
+    Parameters
+    ----------
+    retries
+        The number of times to retry running the code.
+    idle
+        The amount of time to wait in between retries.
+
+    Returns
+    -------
+    keep_alive
+        A coroutine that can be used as an Arq cron function.
+    """
+
+    async def keep_alive(ctx: dict[Any, Any]) -> str:
+        return await _keep_alive(ctx, retries, idle)
+
+    return keep_alive

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -20,7 +20,7 @@ from structlog.stdlib import BoundLogger
 from noteburst.config import WorkerConfig, WorkerKeepAliveSetting
 from noteburst.user import User
 
-from .functions import keep_alive, nbexec, ping, run_python
+from .functions import make_keep_alive, nbexec, ping, run_python
 from .identity import IdentityClaim, IdentityManager
 
 config = WorkerConfig()
@@ -228,6 +228,9 @@ async def shutdown(ctx: dict[Any, Any]) -> None:
 # For info on ignoring the type checking here, see
 # https://github.com/samuelcolvin/arq/issues/249
 cron_jobs: list[cron] = []  # type: ignore [valid-type]
+keep_alive = make_keep_alive(
+    retries=config.worker_keepalive_retries, idle=config.worker_keepalive_idle
+)
 if config.worker_keepalive == WorkerKeepAliveSetting.fast:
     f = cron(keep_alive, second={0, 30}, unique=False)
     cron_jobs.append(f)


### PR DESCRIPTION
### New features

- New worker config options:
  - `worker_keepalive_retries`: How many times to retry the keepalive check.
  - `worker_keepalive_idle`: How long to wait in between each keepalive attempt.

### Bug fixes

- Restart the worker on any exception in the keepalive cron. Some of the exception types changed with the shared Nublado client.