### PR TITLE
DM-49407: Fix keepalive

### DIFF
--- a/changelog.d/20250312_093521_danfuchs_HEAD.md
+++ b/changelog.d/20250312_093521_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Catch more exceptions in the keepalive cron to trigger a worker to restart.

--- a/src/noteburst/worker/functions/keepalive.py
+++ b/src/noteburst/worker/functions/keepalive.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import sys
 from typing import Any
 
-from rubin.nublado.client.exceptions import JupyterWebSocketError
+from rubin.nublado.client.exceptions import (
+    JupyterWebError,
+    JupyterWebSocketError,
+)
 
 
 async def keep_alive(ctx: dict[Any, Any]) -> str:
@@ -30,7 +33,7 @@ async def keep_alive(ctx: dict[Any, Any]) -> str:
             kernel_name="LSST"
         ) as session:
             await session.run_python("print('alive')")
-    except JupyterWebSocketError as e:
+    except (JupyterWebSocketError, JupyterWebError) as e:
         logger.exception("keep_alive error", jupyter_status=e.status)
         if e.status and e.status >= 400 and e.status < 500:
             logger.exception(


### PR DESCRIPTION
The Nublado client is now throwing `JupyterWebError` instead of a `JupyterWebSocketError` for auth errors. This likely changed when Noteburst adopted the shared client.

https://github.com/lsst-sqre/noteburst/pull/109 restarts on all exceptions and adds retries, but I think that's overkill. The past 30 days of logs from `usdfdev` and `usdfprod` show that:
* The vast majority of non-restarting errors have been auth errors, which are unrecoverable, so we don't want to retry them.
* I'm not convinced that restarting the worker would help with the other errors.

```
sum by(error) (count_over_time({app="noteburst", component="worker"} |= `cron:keep_alive failed` | pattern `<_>: <duration> ! cron:<function> failed, <error>` [$__auto]))
```

| Error | Count |
|-------|-------|
|JupyterWebError: ConnectError: [Errno -3] Temporary failure in name resolution|1|
|JupyterWebError: ReadTimeout|9|
|JupyterWebError: Status 403 from POST https://usdf-rsp-dev.slac.stanford.edu/nb/user/bot-noteburst01/api/sessions|130|
|JupyterWebError: Status 403 from POST https://usdf-rsp-dev.slac.stanford.edu/nb/user/bot-noteburst02/api/sessions|455|
|JupyterWebError: Status 403 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst01/api/sessions|778|
|JupyterWebError: Status 403 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst02/api/sessions|778|
|JupyterWebError: Status 403 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst03/api/sessions|837|
|JupyterWebError: Status 500 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst03/api/sessions|1|
|JupyterWebError: Status 500 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst04/api/sessions|1|
|JupyterWebError: Status 503 from POST https://usdf-rsp.slac.stanford.edu/nb/user/bot-noteburst03/api/sessions|1|
