### PR TITLE
DM-49664: Sentry

### DIFF
--- a/changelog.d/20250430_104614_danfuchs_HEAD.md
+++ b/changelog.d/20250430_104614_danfuchs_HEAD.md
@@ -1,0 +1,6 @@
+### New features
+
+- [Sentry](https://sentry.io) integration.
+  * Enabled by setting `SENTRY_DSN` in the environment, which is injected in Phalanx.
+  * Sends errors and traces to the [noteburst project](https://rubin-observatory.sentry.io/projects/noteburst/?project=4509170139594752), which was created by [Prodromos](https://prodromos.lsst.io).
+  * The [traces sample rate](https://docs.sentry.io/concepts/key-terms/sample-rates/#tracing) can be configured. It comes from Phalanx values.

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -157,6 +157,21 @@ class Config(BaseSettings):
         ),
     ] = None
 
+    sentry_traces_sample_rate: Annotated[
+        float,
+        Field(
+            default=0,
+            alias="NOTEBURST_SENTRY_TRACES_SAMPLE_RATE",
+            description=(
+                "If Sentry is enabled (by providing a SENTRY_DSN env var"
+                "value), this is a number between 0 and 1 that is a percentage"
+                "of the number of requests that are traced."
+            ),
+            ge=0,
+            le=1,
+        ),
+    ]
+
     @property
     def arq_redis_settings(self) -> RedisSettings:
         """Create a Redis settings instance for arq."""

--- a/src/noteburst/handlers/internal.py
+++ b/src/noteburst/handlers/internal.py
@@ -19,12 +19,15 @@ internal_router = APIRouter()
 """FastAPI router for all internal handlers."""
 
 
+@internal_router.get("/healthcheck")
 @internal_router.get(
     "/",
     description=(
         "Return metadata about the running application. Can also be used as"
         " a health check. This route is not exposed outside the cluster and"
-        " therefore cannot be used by external clients."
+        " therefore cannot be used by external clients. This route is also"
+        " exposed at /healthcheck so that Sentry tracing will ignore it:"
+        " https://docs.sentry.io/concepts/data-management"
     ),
     response_model_exclude_none=True,
     summary="Internal application metadata",

--- a/src/noteburst/main.py
+++ b/src/noteburst/main.py
@@ -13,6 +13,7 @@ from contextlib import asynccontextmanager
 from importlib.metadata import version
 from pathlib import Path
 
+import sentry_sdk
 import structlog
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
@@ -21,6 +22,7 @@ from safir.dependencies.http_client import http_client_dependency
 from safir.fastapi import ClientRequestError, client_request_error_handler
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.sentry import before_send_handler
 from safir.slack.webhook import SlackRouteErrorHandler
 
 from .config import config
@@ -31,6 +33,11 @@ from .handlers.v1 import v1_router
 
 __all__ = ["app", "config"]
 
+# If SENTRY_DSN is not in the environment, this will do nothing
+sentry_sdk.init(
+    traces_sample_rate=config.sentry_traces_sample_rate,
+    before_send=before_send_handler,
+)
 
 configure_logging(
     profile=config.profile,

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -8,11 +8,13 @@ from typing import Any, ClassVar
 import httpx
 import humanize
 import rubin.nublado.client.models as nc_models
+import sentry_sdk
 import structlog
 from arq import cron
 from rubin.nublado.client import NubladoClient
 from rubin.nublado.client.exceptions import JupyterProtocolError
 from safir.logging import configure_logging
+from safir.sentry import before_send_handler
 from safir.slack.blockkit import SlackMessage, SlackTextField
 from safir.slack.webhook import SlackWebhookClient
 from structlog.stdlib import BoundLogger
@@ -24,6 +26,12 @@ from .functions import keep_alive, nbexec, ping, run_python
 from .identity import IdentityClaim, IdentityManager
 
 config = WorkerConfig()
+
+# If SENTRY_DSN is not in the environment, this will do nothing
+sentry_sdk.init(
+    traces_sample_rate=config.sentry_traces_sample_rate,
+    before_send=before_send_handler,
+)
 
 
 async def _get_client_user(


### PR DESCRIPTION
Add the laziest out-of-the-box (with Safir enhancements) Sentry integration. This does not affect the current Safir Slack error reporting at all. I'll make another PR in the future to convert the Safir Slack reporting fully to Sentry reporting when we all agree on how we want to structure the exceptions.

Goes with [this Phalanx PR](https://github.com/lsst-sqre/phalanx/pull/4619)

* [Sentry Slack notification](https://rubin-obs.slack.com/archives/C07QAQ92RFD/p1745963896902779)
* [Sentry issue page](https://rubin-observatory.sentry.io/issues/6576484887)
* [nbexec task trace](https://rubin-observatory.sentry.io/traces/trace/34eae2af736f4c88bd4407da893f7eec/?node=span-83517a8492e5b87e&node=txn-fb88474731864043886e39d2bca9c4b4&project=4509170139594752&source=traces&statsPeriod=1h&targetId=8ae8dcbbdc5e6411&timestamp=1745964659)
* [Trace from Times Square through Noteburst showing errors](https://rubin-observatory.sentry.io/insights/backend/summary/trace/b0148d27c9bd4a2981c553a64df7956e/?node=txn-f0eac940635044f99158ae27367cf863&project=4509170139594752&query=http.method%3APOST%20transaction.op%3Ahttp.server&referrer=performance-transaction-summary&source=performance_transaction_summary&statsPeriod=1h&timestamp=1745964645&transaction=%2Fnoteburst%2Fv1%2Fnotebooks%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)
* [Trace with no errors](https://rubin-observatory.sentry.io/insights/backend/summary/trace/1d54a479b8ea4ed09722463b455938f7/?node=txn-ad5e9296ce124a13848a261282d17538&project=4509170139594752&query=http.method%3APOST%20transaction.op%3Ahttp.server&referrer=performance-transaction-summary&source=performance_transaction_summary&statsPeriod=1h&timestamp=1745962905&transaction=%2Fnoteburst%2Fv1%2Fnotebooks%2F&unselectedSeries=p100%28%29&unselectedSeries=avg%28%29)