### PR TITLE
DM-51912: Add periodic Arq metrics script

### DIFF
--- a/changelog.d/20250731_140503_danfuchs_HEAD.md
+++ b/changelog.d/20250731_140503_danfuchs_HEAD.md
@@ -1,0 +1,3 @@
+### New features
+
+- Added a script to publish a metric for the number of messages in the Arq queue. This is meant to be run periodically, probably with a Kubernetes CronJob.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-# [project.scripts]
-# example = "noteburst.cli:main"
+[project.scripts]
+noteburst_publish_periodic_metrics = "noteburst.periodic_metrics:publish_periodic_metrics"
+
 [dependency-groups]
 dev = [
     "asgi-lifespan",

--- a/src/noteburst/config.py
+++ b/src/noteburst/config.py
@@ -159,6 +159,16 @@ class Config(BaseSettings):
         ),
     ] = ArqMode.production
 
+    queue_name: Annotated[
+        str,
+        Field(
+            alias="NOTEBURST_WORKER_QUEUE_NAME",
+            description=(
+                "Name of the arq queue that the worker processes from."
+            ),
+        ),
+    ] = "arq:queue"
+
     slack_webhook_url: Annotated[
         HttpUrl | None,
         Field(
@@ -221,16 +231,6 @@ class WorkerConfig(Config):
             ),
         ),
     ]
-
-    queue_name: Annotated[
-        str,
-        Field(
-            alias="NOTEBURST_WORKER_QUEUE_NAME",
-            description=(
-                "Name of the arq queue that the worker processes from."
-            ),
-        ),
-    ] = "arq:queue"
 
     identity_lock_redis_url: Annotated[
         RedisDsn,

--- a/src/noteburst/config/base.py
+++ b/src/noteburst/config/base.py
@@ -1,0 +1,62 @@
+"""Config shared by all Noteburst components."""
+
+from typing import Annotated
+
+from arq.connections import RedisSettings
+from pydantic import Field, RedisDsn
+from pydantic_settings import BaseSettings
+from safir.metrics import MetricsConfiguration, metrics_configuration_factory
+
+__all__ = ["BaseConfig"]
+
+
+class BaseConfig(BaseSettings):
+    """Config shared by all Noteburst components."""
+
+    metrics: Annotated[
+        MetricsConfiguration,
+        Field(
+            default_factory=metrics_configuration_factory,
+            title="Metrics configuration",
+        ),
+    ]
+
+    redis_url: Annotated[
+        RedisDsn,
+        Field(
+            alias="NOTEBURST_REDIS_URL",
+            # Preferred by mypy over a string default
+            default_factory=lambda: RedisDsn("redis://localhost:6379/1"),
+            description=(
+                "URL for the redis instance, used by the worker queue.",
+            ),
+        ),
+    ]
+
+    sentry_traces_sample_rate: Annotated[
+        float,
+        Field(
+            default=0,
+            alias="NOTEBURST_SENTRY_TRACES_SAMPLE_RATE",
+            description=(
+                "If Sentry is enabled (by providing a SENTRY_DSN env var"
+                "value), this is a number between 0 and 1 that is a percentage"
+                "of the number of requests that are traced."
+            ),
+            ge=0,
+            le=1,
+        ),
+    ]
+
+    @property
+    def arq_redis_settings(self) -> RedisSettings:
+        """Create a Redis settings instance for arq."""
+        return RedisSettings(
+            host=self.redis_url.host or "localhost",
+            port=self.redis_url.port or 6379,
+            database=(
+                int(self.redis_url.path.lstrip("/"))
+                if self.redis_url.path
+                else 0
+            ),
+        )

--- a/src/noteburst/config/frontend.py
+++ b/src/noteburst/config/frontend.py
@@ -1,0 +1,106 @@
+"""Config for the Noteburst frontend."""
+
+from typing import Annotated
+
+from pydantic import Field, HttpUrl, SecretStr
+from safir.arq import ArqMode
+from safir.logging import LogLevel, Profile
+
+from .base import BaseConfig
+
+__all__ = ["FrontendConfig"]
+
+
+class FrontendConfig(BaseConfig):
+    """Config for the Noteburst frontend."""
+
+    name: Annotated[str, Field(alias="SAFIR_NAME")] = "Noteburst"
+
+    profile: Annotated[Profile, Field(alias="SAFIR_PROFILE")] = (
+        Profile.production
+    )
+
+    log_level: Annotated[LogLevel, Field(alias="SAFIR_LOG_LEVEL")] = (
+        LogLevel.INFO
+    )
+
+    logger_name: Annotated[
+        str,
+        Field(
+            description=(
+                "The root name of the Python logger, which is also the name "
+                "of the root Python module"
+            )
+        ),
+    ] = "noteburst"
+
+    path_prefix: Annotated[
+        str,
+        Field(
+            "/noteburst",
+            alias="NOTEBURST_PATH_PREFIX",
+            description="The URL path prefix where noteburst is hosted.",
+        ),
+    ] = "/noteburst"
+
+    environment_url: Annotated[
+        HttpUrl,
+        Field(
+            alias="NOTEBURST_ENVIRONMENT_URL",
+            description=(
+                "The base URL of the Rubin Science Platform environment. This "
+                "is used for creating URLs to services, such as JupyterHub."
+            ),
+        ),
+    ]
+
+    jupyterhub_path_prefix: Annotated[
+        str,
+        Field(
+            alias="NOTEBURST_JUPYTERHUB_PATH_PREFIX",
+            description="The path prefix for the JupyterHub service.",
+        ),
+    ] = "/nb/"
+
+    nublado_controller_path_prefix: Annotated[
+        str,
+        Field(
+            alias="NOTEBURST_NUBLADO_CONTROLLER_PATH_PREFIX",
+            description="The path prefix for the Nublado controller service.",
+        ),
+    ] = "/nublado"
+
+    gafaelfawr_token: Annotated[
+        SecretStr,
+        Field(
+            alias="NOTEBURST_GAFAELFAWR_TOKEN",
+            description=(
+                "This token is used to make an admin API call to Gafaelfawr "
+                "to get a token for the user."
+            ),
+        ),
+    ]
+
+    arq_mode: Annotated[
+        ArqMode,
+        Field(
+            alias="NOTEBURST_ARQ_MODE",
+            description=(
+                "The Arq mode. Use 'test' to mock arq/redis for testing."
+            ),
+        ),
+    ] = ArqMode.production
+
+    slack_webhook_url: Annotated[
+        HttpUrl | None,
+        Field(
+            alias="NOTEBURST_SLACK_WEBHOOK_URL",
+            description=(
+                "Webhook URL for sending error messages to a Slack channel."
+            ),
+        ),
+    ] = None
+
+
+config = FrontendConfig()
+"""Configuration for the Noteburst frontend."""

--- a/src/noteburst/config/metrics.py
+++ b/src/noteburst/config/metrics.py
@@ -1,0 +1,27 @@
+"""Config for the Noteburst periodic metrics cron."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from .base import BaseConfig
+
+__all__ = ["PeriodicMetricsConfig"]
+
+
+class PeriodicMetricsConfig(BaseConfig):
+    """Config for the Noteburst periodic metrics cron."""
+
+    queue_names: Annotated[
+        list[str],
+        Field(
+            alias="NOTEBURST_METRICS_QUEUE_NAMES",
+            description=(
+                "Names of the arq queues that the worker processes from."
+            ),
+        ),
+    ] = ["arq:queue"]  # noqa: RUF012
+
+
+config = PeriodicMetricsConfig()
+"""Configuration for the Noteburst periodic metrics cronjob."""

--- a/src/noteburst/handlers/external.py
+++ b/src/noteburst/handlers/external.py
@@ -9,7 +9,7 @@ from safir.metadata import Metadata as SafirMetadata
 from safir.metadata import get_metadata
 from structlog.stdlib import BoundLogger
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 __all__ = ["external_router", "get_index"]
 

--- a/src/noteburst/handlers/internal.py
+++ b/src/noteburst/handlers/internal.py
@@ -11,7 +11,7 @@ or other information that should not be visible outside the Kubernetes cluster.
 from fastapi import APIRouter
 from safir.metadata import Metadata, get_metadata
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 __all__ = ["get_index", "internal_router"]
 

--- a/src/noteburst/main.py
+++ b/src/noteburst/main.py
@@ -25,7 +25,7 @@ from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.sentry import before_send_handler
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from .config import config
+from .config.frontend import config
 from .events import events_dependency
 from .handlers.external import external_router
 from .handlers.internal import internal_router

--- a/src/noteburst/periodic_metrics.py
+++ b/src/noteburst/periodic_metrics.py
@@ -6,7 +6,7 @@ import sentry_sdk
 from safir.metrics import ArqEvents, publish_queue_stats
 from safir.sentry import before_send_handler
 
-from .config import config
+from .config.metrics import config
 
 # If SENTRY_DSN is not in the environment, this will do nothing
 sentry_sdk.init(
@@ -27,11 +27,12 @@ def publish_periodic_metrics() -> None:
             await manager.initialize()
             arq_events = ArqEvents()
             await arq_events.initialize(manager)
-            await publish_queue_stats(
-                queue=config.queue_name,
-                arq_events=arq_events,
-                redis_settings=config.arq_redis_settings,
-            )
+            for queue in config.queue_names:
+                await publish_queue_stats(
+                    queue=queue,
+                    arq_events=arq_events,
+                    redis_settings=config.arq_redis_settings,
+                )
         finally:
             await manager.aclose()
 

--- a/src/noteburst/periodic_metrics.py
+++ b/src/noteburst/periodic_metrics.py
@@ -1,0 +1,38 @@
+"""A script for publishing periodic app metrics."""
+
+import asyncio
+
+import sentry_sdk
+from safir.metrics import ArqEvents, publish_queue_stats
+from safir.sentry import before_send_handler
+
+from .config import config
+
+# If SENTRY_DSN is not in the environment, this will do nothing
+sentry_sdk.init(
+    traces_sample_rate=config.sentry_traces_sample_rate,
+    before_send=before_send_handler,
+)
+
+
+def publish_periodic_metrics() -> None:
+    """Publish queue statistics events.
+
+    This should be run on a schedule.
+    """
+
+    async def publish() -> None:
+        manager = config.metrics.make_manager()
+        try:
+            await manager.initialize()
+            arq_events = ArqEvents()
+            await arq_events.initialize(manager)
+            await publish_queue_stats(
+                queue=config.queue_name,
+                arq_events=arq_events,
+                redis_settings=config.arq_redis_settings,
+            )
+        finally:
+            await manager.aclose()
+
+    asyncio.run(publish())

--- a/src/noteburst/worker/identity.py
+++ b/src/noteburst/worker/identity.py
@@ -12,7 +12,7 @@ from typing import Annotated
 import yaml
 from pydantic import BaseModel, Field, RootModel
 
-from noteburst.config import WorkerConfig
+from noteburst.config.worker import WorkerConfig
 
 
 class IdentityModel(BaseModel):

--- a/src/noteburst/worker/main.py
+++ b/src/noteburst/worker/main.py
@@ -17,7 +17,7 @@ from safir.sentry import before_send_handler
 from safir.slack.blockkit import SlackMessage, SlackTextField
 from safir.slack.webhook import SlackWebhookClient
 
-from noteburst.config import (
+from noteburst.config.worker import (
     JupyterImageSelector,
     WorkerConfig,
     WorkerKeepAliveSetting,

--- a/src/noteburst/worker/user.py
+++ b/src/noteburst/worker/user.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 import httpx
 from rubin.nublado.client.models import User as NubladoUser
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 __all__ = ["AuthenticatedUser", "User"]
 

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 
 @pytest.mark.asyncio

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin
 import httpx
 import respx
 
-from noteburst.config import config
+from noteburst.config.frontend import config
 
 __all__ = ["make_gafaelfawr_token", "mock_gafaelfawr"]
 


### PR DESCRIPTION
Added a script to publish a metric for the number of messages in the Arq queue.

Goes with:
* [This Safir PR](https://github.com/lsst-sqre/safir/pull/422), which adds a method to get stats for an Arq queue
* [This Phalanx PR](https://github.com/lsst-sqre/phalanx/pull/5183), which adds a CronJob to call this script periodically

<img width="1179" height="627" alt="image" src="https://github.com/user-attachments/assets/8ccbad75-c45f-44b4-bf4b-1d310a6787e3" />
