### PR TITLE
DM-55493: cap fastapi below 0.140 (faststream incompatibility)

### DIFF
--- a/changelog.d/20260727_122503_jsick_DM_55493.md
+++ b/changelog.d/20260727_122503_jsick_DM_55493.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Constrain FastAPI to `<0.140`. FastAPI 0.140.0 made `Dependant` a slots dataclass, which breaks FastStream's FastAPI plugin (it sets extra attributes on `Dependant` instances). The cap can be removed once [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959) is fixed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
 requires-python = ">=3.14"
 dependencies = [
     # These dependencies are for fastapi including some optional features.
-    "fastapi",
+    # fastapi 0.140 made Dependant a slots dataclass, which breaks FastStream's
+    # FastAPI plugin (it sets attributes on Dependant instances).
+    # TODO: remove when ag2ai/faststream#2959 is fixed
+    "fastapi<0.140",
     "starlette",
     "uvicorn[standard]",
 

--- a/uv.lock
+++ b/uv.lock
@@ -1377,7 +1377,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "aioredlock" },
-    { name = "fastapi" },
+    { name = "fastapi", specifier = "<0.140" },
     { name = "httpx" },
     { name = "humanize" },
     { name = "pydantic" },


### PR DESCRIPTION
Cap FastAPI at `<0.140` in `[project] dependencies` so a future `make update` cannot silently bake a broken FastAPI into the lockfile.

## Why

FastAPI 0.140.0 (2026-07-24, [fastapi/fastapi#16049](https://github.com/fastapi/fastapi/pull/16049) "Reduce memory usage in dependencies") changed `Dependant` to `@dataclass(slots=True)`. FastStream's FastAPI plugin monkey-patches `dependant.model`, `.custom_fields` and `.flat_params` onto that instance (`faststream/_internal/fastapi/get_dependant.py:131,135,136`), which now raises:

```
AttributeError: 'Dependant' object has no attribute 'model' and no __dict__ for setting new attributes
```

Upstream bug: [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959) — open and unfixed on main (note the repo moved from `airtai/` to `ag2ai/`). faststream 0.7.2 is the latest release and is still broken; downgrading does not help either, since 0.6.7 carries the same patch.

Noteburst pulls FastStream in via `safir[kafka]`.

## Impact today

The committed `uv.lock` still pins a pre-break FastAPI (0.136.3), so production and per-PR CI are green. Only the scheduled **Periodic CI** job — which resolves dependencies unpinned — is red. This PR is preventative: without the cap, the next `make update` would resolve to 0.140.x and ship a broken image.

## Changes

- `pyproject.toml`: `"fastapi"` -> `"fastapi<0.140"`, with a `# TODO: remove when ag2ai/faststream#2959 is fixed` comment.
- `uv.lock`: relocked with plain `uv lock` (deliberately **not** `--upgrade`). The only change is the constraint metadata:

  ```diff
  -    { name = "fastapi" },
  +    { name = "fastapi", specifier = "<0.140" },
  ```

  The resolved fastapi version is unchanged at **0.136.3**. No other package moved.
- Changelog fragment under `changelog.d/`.

## Testing

`tox -e py,typing` passes locally: 9 tests passed, mypy clean across 37 source files.

Note this run exercises the locked FastAPI 0.136.3, so it confirms the cap breaks nothing — it does not itself reproduce the 0.140 failure.

## Follow-up

Remove the cap once [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959) ships a fix.
