### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

- Sync the vendored `ruff-shared.toml` with the current `fastapi_safir_app` template (lsst/templates commit dd8e4b26), which adds `CPY001` to the `[lint]` ignore list now that ruff 0.16.0 stabilized missing-copyright-notice out of preview.
- Config-only, single-line diff. No other template drift found; `pyproject.toml` `[tool.ruff]` settings (per-file-ignores, isort `known-first-party`) needed no changes.

## Validation

- `ruff check .` passes clean under both the pinned ruff 0.15.15 and ruff 0.16.0.

Jira: https://rubinobs.atlassian.net/browse/DM-55493