### PR TITLE
DM-55493: Adopt prek in place of pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,12 +59,12 @@ dev = [
     "pytest-sugar",
     "respx",
     "rubin-repertoire",
+    "uv",
 ]
 
 lint = [
     "prek",
     "ruff",
-    "uv",
 ]
 
 typing = [

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -7,11 +7,15 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
-# Determine the current frozen uv version. Since the lint group depends on
-# pre-commit-uv, uv should always be part of its dependencies and thus updated
-# when running uv lock --upgrade, which should be run before this script.
-uv_version=$(uv export -q --no-hashes --only-group lint \
-             | grep ^uv== | sed 's/.*=//')
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
 
 # Replace the version in the env variables in GitHub Actions workflows.
 for f in .github/workflows/*.yaml; do
@@ -24,7 +28,8 @@ for f in .github/workflows/*.yaml; do
     fi
 done
 
-# Replace the version in any Dockerfiles.
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
 for f in Dockerfile*; do
     sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
     if ! cmp -s "$f" "${f}.n"; then

--- a/uv.lock
+++ b/uv.lock
@@ -1355,6 +1355,7 @@ dev = [
     { name = "pytest-sugar" },
     { name = "respx" },
     { name = "rubin-repertoire" },
+    { name = "uv" },
 ]
 docs = [
     { name = "documenteer", extra = ["guide"] },
@@ -1363,7 +1364,6 @@ docs = [
 lint = [
     { name = "prek" },
     { name = "ruff" },
-    { name = "uv" },
 ]
 tox = [
     { name = "tox" },
@@ -1403,6 +1403,7 @@ dev = [
     { name = "pytest-sugar" },
     { name = "respx" },
     { name = "rubin-repertoire" },
+    { name = "uv" },
 ]
 docs = [
     { name = "documenteer", extras = ["guide"] },
@@ -1411,7 +1412,6 @@ docs = [
 lint = [
     { name = "prek" },
     { name = "ruff" },
-    { name = "uv" },
 ]
 tox = [
     { name = "tox" },


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

This repo had already landed half of the prek migration before this PR: the `Makefile` (`init`/`update-deps` targets) and `tox.ini` (`[testenv:lint]`) already invoked `prek` directly, and no CI workflow calls `pre-commit`/`prek` directly (only a comment referencing `.pre-commit-config.yaml`, left as-is). So this PR only applies what was genuinely missing:

- **Taskrunner branch**: this is a **tox** repo (`tox.ini`, `[testenv:lint]`) — already correct, untouched.
- **pyproject.toml**: moved `"uv"` from the `lint` dependency group to the `dev` group (`lint` is now just `prek` + `ruff`, matching the template).
- **scripts/update-uv-version.sh**: replaced with the current `lsst/templates` `fastapi_safir_app` version (step 7 applied — the file already existed).
- `uv lock` to reconcile the lockfile; no other dependency changes, `fastapi` pin untouched.
- `.pre-commit-config.yaml` left unchanged, as directed.

Verified:
- `uv run --only-group=lint prek run --all-files` passes.
- `tox -e lint` passes.
- Done-check greps and the dependency-groups check all pass (`lint == ['prek', 'ruff']`, `dev` contains `uv`).

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ